### PR TITLE
Create MNLI dir under current dir

### DIFF
--- a/data/get_data.bash
+++ b/data/get_data.bash
@@ -1,6 +1,6 @@
 
 #get MedNLI
-mkdir -p /MedNLI
+mkdir -p ./MedNLI
 
 #getRQE
 mkdir -p ./RQE


### PR DESCRIPTION
There is a typo in `get_data.sh`that tries to create MNLI under the home directory (`/`). On some systems, this results in an error: `mkdir: cannot create directory ‘/MedNLI’: Permission denied`.

This is easily fixed by creating the directory at `./MNLI` instead.