### PR TITLE
Fix the awk command for BIOSSES dataset

### DIFF
--- a/data/get_data.bash
+++ b/data/get_data.bash
@@ -48,11 +48,10 @@ mkdir -p ../ClinicalSTS
 #get BIOSSES
 mkdir -p ../BIOSSES
 cd ../BIOSSES
-wget http://tabilab.cmpe.boun.edu.tr/BIOSSES/Downloads/BIOSSES-Dataset.rar
 wget https://bitbucket.org/gizemsogancioglu/biosses-resources/raw/52a77008d6c80ea570fa717136421b8c81683aa2/resources.zip
 unzip -p resources.zip correlationResult/groundTruth/test.txt > STS.gs.BIOSSES.txt
 unzip -p resources.zip sentencePairsData/pairs.txt > temp.txt
-awk 'BEGIN{FS="\t|    "}{print$2 $3}' temp.txt > STS.input.BIOSSES.txt
+awk 'BEGIN{FS="\t"}{printf ("%s\t%s\n", $2, $3)}' temp.txt > STS.input.BIOSSES.txt
 
 #prepare data files
 python ../prepare_data.py


### PR DESCRIPTION
The `awk` command for reformatting the BIOESS dataset in `get_data.sh` is not correct AFAICT. It creates a text file of sentence pairs separated by spaces, rather than tabs. This causes an error in `senteval/sts.py`, as it expects tab-delineated pairs.

Also, there is a `wget` command to download a `rar` file which is never used, so I removed it.